### PR TITLE
add concurrency limit

### DIFF
--- a/src/consumer/EventTriangleAPI.Consumer.Presentation/Program.cs
+++ b/src/consumer/EventTriangleAPI.Consumer.Presentation/Program.cs
@@ -63,6 +63,8 @@ builder.Services.AddMassTransit(config =>
         
         cfg.ReceiveEndpoint("event-queue", c =>
         {
+            c.PrefetchCount = 1;
+            c.UseConcurrencyLimit(1);
             c.ConfigureConsumer<EventConsumer>(ctx);
         });
     });


### PR DESCRIPTION
Before the changes, each method of the consumer could finish execution in a different order than the events arrive, because the execution time of a method cannot be single. Now methods are executed in strict order, execution of the next method will not begin until the previous method has finished execution.