### PR TITLE
AZ400-309. Move configure AKS cluster to separate pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,4 @@ and this project adheres to [Semantic Versioning v2.0.0](https://semver.org/spec
 - Merge two docker builds templates for docker build and push
 - Add integration tests project to auth service
 - Create a separate powershell script for build and tag docker images
+- Move configure AKS cluster to separate pipeline

--- a/build/configure-aks-cluster.yml
+++ b/build/configure-aks-cluster.yml
@@ -1,0 +1,40 @@
+#pr:
+#  paths:
+#    include:
+#      - terraform
+#      - build/terraform-plan-apply.yml
+#    exclude:
+#      - terraform/README.md
+
+#trigger:
+#  batch: true
+#  branches:
+#    include:
+#      - docs
+
+trigger: none
+pr: none
+
+variables:
+  - group: Azure_Terraform_Integration
+  - group: Postgres_Rabbit_Connection_Credentials
+  - group: Terraform_Auto_Tfvars_Json_Transform
+  - group: AKS_Settings
+  - group: Prefix_Library
+  - name: System.Debug
+    value: 'false'
+
+stages:
+  - template: templates/configure-cluster-stages.yml
+    parameters:
+      vmImage: ubuntu-latest
+      environment: aks
+      workingDirectory: $(System.DefaultWorkingDirectory)/kubernetes
+      serviceConnection: Azure_Connection
+      azureResourceGroup: $(library-aks-resource-group)
+      kubernetesCluster: $(library-aks-cluster-name)
+      namespace: 'event-triangle'
+      rabbitMqUser: $(library-rabbitmq-user)
+      rabbitMqPassword: $(library-rabbitmq-password)
+      transformTargetFiles: |
+        secrets/connection-secrets.yaml

--- a/build/templates/configure-cluster-stages.yml
+++ b/build/templates/configure-cluster-stages.yml
@@ -34,19 +34,9 @@ parameters:
     displayName: 'RabbitMQ Password'
     type: string
 
-  - name: dependsOn
-    displayName: 'Depends On'
-    type: object
-
-  - name: condition
-    displayName: 'Condition'
-    type: string
-
 stages:
   - stage: 'Configure_AKS_${{ parameters.environment }}'
     displayName: 'Configure_AKS_${{ parameters.environment }}'
-    dependsOn: ${{ parameters.dependsOn }}
-    condition: succeeded('${{ parameters.condition }}')
     jobs:
       - deployment: 'Configure_AKS_${{ parameters.environment }}'
         displayName: 'Configure_AKS_${{ parameters.environment }}'
@@ -115,13 +105,13 @@ stages:
                   inputs:
                     targetType: 'filePath'
                     filePath: ${{ parameters.workingDirectory }}/helm-install-rabbit-mq/deploy-rabbitmq-helm.ps1
-                    arguments: '-HelmReleaseName event-rabbitmq 
-                                -Namespace ${{ parameters.namespace }} 
-                                -RabbitMqUsername ${{ parameters.rabbitMqUser }} 
+                    arguments: '-HelmReleaseName event-rabbitmq
+                                -Namespace ${{ parameters.namespace }}
+                                -RabbitMqUsername ${{ parameters.rabbitMqUser }}
                                 -RabbitMqPassword ${{ parameters.rabbitMqPassword }}'
                     pwsh: true
                     workingDirectory: ${{ parameters.workingDirectory }}
-                    
+
                 - task: PowerShell@2
                   displayName: 'Deploy CertManager'
                   inputs:
@@ -136,16 +126,16 @@ stages:
                   inputs:
                     targetType: 'filePath'
                     filePath: ${{ parameters.workingDirectory }}/scripts/wait-deployments.ps1
-                    arguments: '-Namespace ${{ parameters.namespace }} 
-                                -RabbitRelease event-rabbitmq 
+                    arguments: '-Namespace ${{ parameters.namespace }}
+                                -RabbitRelease event-rabbitmq
                                 -PostgresDeployment postgresdb'
                     pwsh: true
                     workingDirectory: ${{ parameters.workingDirectory }}
-                    
+
                 - task: PowerShell@2
                   displayName: 'Print Public IPs'
                   inputs:
                     targetType: 'filePath'
                     filePath: ${{ parameters.workingDirectory }}/scripts/print-ip.ps1
                     pwsh: true
-                    workingDirectory: ${{ parameters.workingDirectory }}    
+                    workingDirectory: ${{ parameters.workingDirectory }}

--- a/build/templates/docker-build-push-jobs.yml
+++ b/build/templates/docker-build-push-jobs.yml
@@ -125,26 +125,6 @@ jobs:
               projects: '${{ parameters.integrationTestsProjectPath }}'
               arguments: '--no-build --configuration ${{ parameters.buildConfiguration }} --collect "Code Coverage"'
 
-#      - bash: |
-#          GIT_VERSION_IMAGE="${{ parameters.dockerRegistryUrl }}/${{ parameters.imageRepository }}:$(GitVersion.SemVer)"
-#          LATEST_VERSION_IMAGE="${{ parameters.dockerRegistryUrl }}/${{ parameters.imageRepository }}:latest"
-#          echo "GIT_VERSION_IMAGE: $GIT_VERSION_IMAGE"
-#          echo "LATEST_VERSION_IMAGE: $LATEST_VERSION_IMAGE"
-#
-#          ACR_GIT_VERSION_IMAGE="${{ parameters.acrRegistryUrl }}/${{ parameters.imageRepository }}:$(GitVersion.SemVer)"
-#          ACR_LATEST_VERSION_IMAGE="${{ parameters.acrRegistryUrl }}/${{ parameters.imageRepository }}:latest"
-#          echo "ACR_GIT_VERSION_IMAGE: $ACR_GIT_VERSION_IMAGE"
-#          echo "ACR_LATEST_VERSION_IMAGE: $ACR_LATEST_VERSION_IMAGE"
-#
-#          docker build --build-arg FRONT_API_URL="${{ parameters.dockerBuildParameterUrl }}" \
-#                       --build-arg VERSION=$(GitVersion.SemVer) -t "$GIT_VERSION_IMAGE" \
-#                       -f ${{ parameters.dockerfilePath }} .
-#          docker tag "$GIT_VERSION_IMAGE" "$LATEST_VERSION_IMAGE"
-#          docker tag "$GIT_VERSION_IMAGE" "$ACR_LATEST_VERSION_IMAGE"
-#          docker tag "$GIT_VERSION_IMAGE" "$ACR_GIT_VERSION_IMAGE"
-#        workingDirectory: ${{ parameters.workingDirectoryForDocker }}
-#        displayName: 'Build Docker Image'
-
       - task: PowerShell@2
         displayName: 'Build Docker Image'
         inputs:

--- a/build/terraform-create-aks-cluster.yml
+++ b/build/terraform-create-aks-cluster.yml
@@ -62,19 +62,3 @@ stages:
       environment: 'aks'
       dependsOn: [ '${{ variables.planStageName }}' ]
       condition: ${{ variables.planStageName }}
-
-  - template: templates/azure-k8s-configure-stages.yml
-    parameters:
-      vmImage: ubuntu-latest
-      environment: aks
-      workingDirectory: $(System.DefaultWorkingDirectory)/kubernetes
-      serviceConnection: Azure_Connection
-      azureResourceGroup: $(library-aks-resource-group)
-      kubernetesCluster: $(library-aks-cluster-name)
-      namespace: 'event-triangle'
-      rabbitMqUser: $(library-rabbitmq-user)
-      rabbitMqPassword: $(library-rabbitmq-password)
-      dependsOn: [ '${{ variables.applyStageName }}' ]
-      condition: ${{ variables.applyStageName }}
-      transformTargetFiles: |
-        secrets/connection-secrets.yaml


### PR DESCRIPTION
## [1.0.0] - In Progress

### Changed

- Terraform tech debt
- HELM charts
- Merge gitignore files
- Update gitversion tasks
- HELM deployment pipelines
- Terraform infrastructure provision azure pipelines
- Cloudflare DNS automation using PowerShell
- Move ACR to separate resource group
- K8s Rollout deploy pipeline deprecated
- Merge two docker builds templates for docker build and push
- Add integration tests project to auth service
- Create a separate powershell script for build and tag docker images
- Move configure AKS cluster to separate pipeline