### PR TITLE
AZ400-304. Manage Cloudflare DNS record using Postman and PowerShell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,4 @@ and this project adheres to [Semantic Versioning v2.0.0](https://semver.org/spec
 - Add integration tests project to auth service
 - Create a separate powershell script for build and tag docker images
 - Move configure AKS cluster to separate pipeline
+- Cloudflare DNS automation using PowerShell in Azure pipelines

--- a/build/configure-aks-cluster.yml
+++ b/build/configure-aks-cluster.yml
@@ -20,6 +20,7 @@ variables:
   - group: Postgres_Rabbit_Connection_Credentials
   - group: Terraform_Auto_Tfvars_Json_Transform
   - group: AKS_Settings
+  - group: Cloudflare_configuration
   - group: Prefix_Library
   - name: System.Debug
     value: 'false'
@@ -27,7 +28,7 @@ variables:
 stages:
   - template: templates/configure-cluster-stages.yml
     parameters:
-      vmImage: ubuntu-latest
+      vmImage: windows-latest
       environment: aks
       workingDirectory: $(System.DefaultWorkingDirectory)/kubernetes
       serviceConnection: Azure_Connection
@@ -36,5 +37,7 @@ stages:
       namespace: 'event-triangle'
       rabbitMqUser: $(library-rabbitmq-user)
       rabbitMqPassword: $(library-rabbitmq-password)
+      cloudflareApiKey: $(cloudflare-api-key)
+      cloudflareZone: $(cloudflare-zone-name)
       transformTargetFiles: |
         secrets/connection-secrets.yaml

--- a/build/templates/configure-cluster-stages.yml
+++ b/build/templates/configure-cluster-stages.yml
@@ -148,3 +148,4 @@ stages:
                     filePath: $(System.DefaultWorkingDirectory)/cloudflare/Main.ps1
                     arguments: '-ApiToken ${{ parameters.cloudflareApiKey }} -ZoneName ${{ parameters.cloudflareZone }}'
                     pwsh: true
+                    workingDirectory: '$(System.DefaultWorkingDirectory)/cloudflare'

--- a/build/templates/configure-cluster-stages.yml
+++ b/build/templates/configure-cluster-stages.yml
@@ -1,5 +1,6 @@
 parameters:
   - name: vmImage
+    default: 'windows-latest'
     type: string
 
   - name: environment
@@ -32,6 +33,14 @@ parameters:
 
   - name: rabbitMqPassword
     displayName: 'RabbitMQ Password'
+    type: string
+
+  - name: cloudflareApiKey
+    displayName: 'Cloudflare API Token'
+    type: string
+
+  - name: cloudflareZone
+    displayName: 'Zone name of DNS in cloudflare (e.g razumovsky.me)'
     type: string
 
 stages:
@@ -133,9 +142,10 @@ stages:
                     workingDirectory: ${{ parameters.workingDirectory }}
 
                 - task: PowerShell@2
-                  displayName: 'Print Public IPs'
+                  displayName: 'Configure Cloudflare DNS'
                   inputs:
                     targetType: 'filePath'
-                    filePath: ${{ parameters.workingDirectory }}/scripts/print-ip.ps1
+                    filePath: ${{ parameters.workingDirectory }}/cloudflare/Main.ps1
+                    arguments: '-ApiToken ${{ parameters.cloudflareApiKey }} -ZoneName ${{ parameters.cloudflareZone }}'
                     pwsh: true
                     workingDirectory: ${{ parameters.workingDirectory }}

--- a/build/templates/configure-cluster-stages.yml
+++ b/build/templates/configure-cluster-stages.yml
@@ -145,7 +145,6 @@ stages:
                   displayName: 'Configure Cloudflare DNS'
                   inputs:
                     targetType: 'filePath'
-                    filePath: ${{ parameters.workingDirectory }}/cloudflare/Main.ps1
+                    filePath: $(System.DefaultWorkingDirectory)/cloudflare/Main.ps1
                     arguments: '-ApiToken ${{ parameters.cloudflareApiKey }} -ZoneName ${{ parameters.cloudflareZone }}'
                     pwsh: true
-                    workingDirectory: ${{ parameters.workingDirectory }}

--- a/build/templates/docker-build-push-jobs.yml
+++ b/build/templates/docker-build-push-jobs.yml
@@ -175,6 +175,8 @@ jobs:
           publishLocation: 'Container'
 
       - task: PublishBuildArtifacts@1
+        displayName: 'Publish Manifests'
         inputs:
           pathToPublish: '$(System.DefaultWorkingDirectory)/kubernetes'
-          artifactName: k8s-manifests
+          artifactName: 'k8s-manifests'
+          publishLocation: 'Container'


### PR DESCRIPTION
## [1.0.0] - In Progress

### Changed

- Terraform tech debt
- HELM charts
- Merge gitignore files
- Update gitversion tasks
- HELM deployment pipelines
- Terraform infrastructure provision azure pipelines
- Cloudflare DNS automation using PowerShell
- Move ACR to separate resource group
- K8s Rollout deploy pipeline deprecated
- Merge two docker builds templates for docker build and push
- Add integration tests project to auth service
- Create a separate powershell script for build and tag docker images
- Move configure AKS cluster to separate pipeline
- Cloudflare DNS automation using PowerShell in Azure pipelines