### PR TITLE
AZ400-312. Move ingress config, certificate and cert manager manifests to auth service HELM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@ and this project adheres to [Semantic Versioning v2.0.0](https://semver.org/spec
 - Cloudflare DNS automation using PowerShell in Azure pipelines
 - Configure CD with AKS and HELM
 - Helm deploy powershell script
+- Move ingress and certificates to HELM chart

--- a/helm/README.md
+++ b/helm/README.md
@@ -25,7 +25,8 @@
 - helm install auth-service-chart .\auth-service-chart\ --values .\auth-service-chart\values.yaml --namespace "event-triangle"
 - helm install consumer-service-chart .\consumer-service-chart\ --values .\consumer-service-chart\values.yaml --namespace "event-triangle"
 - helm install sender-service-chart .\sender-service-chart\ --values .\sender-service-chart\values.yaml --namespace "event-triangle"
-- helm upgrade --install event-triangle-auth .\helm\auth-service-chart --values .\helm\auth-service-chart\values.yaml --set image.tag="0.1.3-helm.527" --namespace "event-triangle"
+- helm upgrade --install auth-service-chart .\helm\auth-service-chart --values .\helm\auth-service-chart\values.yaml --set image.tag="0.1.3-helm.527" --namespace "event-triangle"
+- helm upgrade --install auth-service-chart .\helm\auth-service-chart --values .\helm\auth-service-chart\values.yaml --namespace "event-triangle"
 
 ## HELM Upgrade
 

--- a/helm/auth-service-chart/templates/certificate-issuer.yaml
+++ b/helm/auth-service-chart/templates/certificate-issuer.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: kolosovp94@gmail.com
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    solvers:
+      - http01:
+          ingress:
+            class: nginx

--- a/helm/auth-service-chart/templates/ingress.yaml
+++ b/helm/auth-service-chart/templates/ingress.yaml
@@ -1,0 +1,32 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ing-event-triangle-auth
+  namespace: event-triangle
+  annotations:
+    nginx.ingress.kubernetes.io/enable-cors: 'true'
+    nginx.ingress.kubernetes.io/cors-allow-headers: 'Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,Accept-Language'
+    nginx.ingress.kubernetes.io/cors-max-age: '600'
+    nginx.ingress.kubernetes.io/proxy-body-size: '12m'
+    nginx.ingress.kubernetes.io/rewrite-target: '/'
+    nginx.ingress.kubernetes.io/use-regex: 'true'
+    kubernetes.io/tls-acme: 'true'
+    nginx.ingress.kubernetes.io/ssl-redirect: 'true'
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - auth-eventtriangle.razumovsky.me
+      secretName: razumovsky-me-tls
+  rules:
+    - host: auth-eventtriangle.razumovsky.me
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Release.Name }}-service
+                port:
+                  number: 80

--- a/helm/consumer-service-chart/templates/service.yaml
+++ b/helm/consumer-service-chart/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-service
+  name: event-triangle-consumer-service
   namespace: {{ .Values.namespace }}
 spec:
   selector:

--- a/helm/sender-service-chart/templates/service.yaml
+++ b/helm/sender-service-chart/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-service
+  name: event-triangle-sender-service
   namespace: {{ .Values.namespace }}
 spec:
   selector:


### PR DESCRIPTION
## [1.0.0] - In Progress

### Changed

- Terraform tech debt
- HELM charts
- Merge gitignore files
- Update gitversion tasks
- HELM deployment pipelines
- Terraform infrastructure provision azure pipelines
- Cloudflare DNS automation using PowerShell
- Move ACR to separate resource group
- K8s Rollout deploy pipeline deprecated
- Merge two docker builds templates for docker build and push
- Add integration tests project to auth service
- Create a separate powershell script for build and tag docker images
- Move configure AKS cluster to separate pipeline
- Cloudflare DNS automation using PowerShell in Azure pipelines
- Configure CD with AKS and HELM
- Helm deploy powershell script
- Move ingress and certificates to HELM chart